### PR TITLE
Add ImageURL, Date, and Type to MaterialDto

### DIFF
--- a/Core/MaterialDto.cs
+++ b/Core/MaterialDto.cs
@@ -1,4 +1,4 @@
 namespace blueberry.Core;
 
-public record MaterialDto(int Id, string Title, PrimitiveCollection<string> Tags);
-public record MaterialDetailsDto(int Id, string Title, PrimitiveCollection<string> Tags, string ShortDescription, string? ImageUrl, string Type, DateTime Date) : MaterialDto(Id, Title, Tags);
+public record MaterialDto(int Id, string Title, PrimitiveCollection<string> Tags, string? ImageUrl, string Type, DateTime Date);
+public record MaterialDetailsDto(int Id, string Title, PrimitiveCollection<string> Tags, string ShortDescription, string? ImageUrl, string Type, DateTime Date) : MaterialDto(Id, Title, Tags, ImageUrl, Type, Date);

--- a/Infrastructure.Tests/MaterialRepositoryTests.cs
+++ b/Infrastructure.Tests/MaterialRepositoryTests.cs
@@ -43,12 +43,12 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}),
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"})
+            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"},  "",  "Book",  new DateTime(2013, 4, 20)),
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}, "", "Book", new DateTime(2021, 2, 26)),
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29)),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
+            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"}, "", "Video", new DateTime(2021, 11, 12))
         };
 
         Assert.Equal(expected, result);
@@ -62,12 +62,12 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}),
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"})
+            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"},  "",  "Book",  new DateTime(2013, 4, 20)),
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}, "", "Book", new DateTime(2021, 2, 26)),
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29)),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
+            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"}, "", "Video", new DateTime(2021, 11, 12))
         };
 
         Assert.Equal(expected, result);
@@ -81,12 +81,12 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}),
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"})
+            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"},  "",  "Book",  new DateTime(2013, 4, 20)),
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}, "", "Book", new DateTime(2021, 2, 26)),
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29)),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
+            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"}, "", "Video", new DateTime(2021, 11, 12))
         };
 
         Assert.Equal(expected, result);
@@ -100,7 +100,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
         };
 
         Assert.Equal(expected, result);
@@ -114,10 +114,10 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"})
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29)),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
+            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"}, "", "Video", new DateTime(2021, 11, 12))
         };
 
         Assert.Equal(expected, result);
@@ -130,7 +130,7 @@ public class MaterialRepositoryTests
         var result = await _repository.Search(options);
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1))
         };
 
         Assert.Equal(expected, result);
@@ -144,8 +144,8 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29))
         };
 
         Assert.Equal(expected, result);
@@ -159,9 +159,9 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"})
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
+            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"}, "", "Video", new DateTime(2021, 11, 12))
         };
 
         Assert.Equal(expected, result);
@@ -175,8 +175,8 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"})
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
+            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"}, "", "Video", new DateTime(2021, 11, 12))
         };
 
         Assert.Equal(expected, result);
@@ -190,11 +190,11 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}),
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"},  "",  "Book",  new DateTime(2013, 4, 20)),
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}, "", "Book", new DateTime(2021, 2, 26)),
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29)),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29))
         };
 
         Assert.Equal(expected, result);
@@ -207,8 +207,8 @@ public class MaterialRepositoryTests
         var result = await _repository.Search(options);
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}),
+            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"},  "",  "Book",  new DateTime(2013, 4, 20)),
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}, "", "Book", new DateTime(2021, 2, 26)),
         };
 
         Assert.Equal(expected, result);
@@ -222,7 +222,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
         };
 
         Assert.Equal(expected, result);
@@ -236,7 +236,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1))
         };
 
         Assert.Equal(expected, result);
@@ -261,7 +261,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1))
         };
 
         Assert.Equal(expected, result);
@@ -275,7 +275,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29))
         };
 
         Assert.Equal(expected, result);
@@ -290,7 +290,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29))
         };
 
         Assert.Equal(expected, result);
@@ -304,8 +304,8 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29))
         };
 
         Assert.Equal(expected, result);
@@ -330,7 +330,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"})
+            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"},  "",  "Book",  new DateTime(2013, 4, 20))
         };
 
         Assert.Equal(expected, result);
@@ -344,7 +344,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"})
+            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string> {"Mobile", "C#"}, "", "Video", new DateTime(2021, 11, 12))
         };
 
         Assert.Equal(expected, result);
@@ -358,9 +358,9 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29)),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29))
         };
 
         Assert.Equal(expected, result);
@@ -379,7 +379,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
         };
 
         Assert.Equal(expected, result);
@@ -398,7 +398,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
         };
 
         Assert.Equal(expected, result);
@@ -417,7 +417,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"}),
+            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"},  "",  "Book",  new DateTime(2013, 4, 20)),
         };
 
         Assert.Equal(expected, result);
@@ -436,8 +436,8 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1)),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
         };
 
         Assert.Equal(expected, result);
@@ -456,7 +456,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"})
+            new MaterialDto(1, "OOSE", new PrimitiveCollection<string> {"Software Engineering"},  "",  "Book",  new DateTime(2013, 4, 20))
         };
 
         Assert.Equal(expected, result);
@@ -475,8 +475,8 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}),
-            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29)),
+            new MaterialDto(10, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 1))
         };
 
         Assert.Equal(expected, result);
@@ -495,7 +495,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29))
         };
 
         Assert.Equal(expected, result);
@@ -514,7 +514,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"})
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29))
         };
 
         Assert.Equal(expected, result);
@@ -533,7 +533,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"})
+            new MaterialDto(9, "Lecture 9", new PrimitiveCollection<string> {"Software Engineering"}, "", "Video", new DateTime(2021, 9, 29))
         };
 
         Assert.Equal(expected, result);
@@ -552,7 +552,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"})
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string> {"C#"}, "", "Book", new DateTime(2021, 2, 26))
         };
 
         Assert.Equal(expected, result);
@@ -571,7 +571,7 @@ public class MaterialRepositoryTests
         var result = await _repository.Search(options);
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
         };
 
         Assert.Equal(expected, result);
@@ -590,7 +590,7 @@ public class MaterialRepositoryTests
         var result = await _repository.Search(options);
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string>() {"C#"})
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string>() {"C#"}, "", "Book", new DateTime(2021, 2, 26))
         };
 
         Assert.Equal(expected, result);
@@ -610,7 +610,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string>() {"Mobile", "C#"})
+            new MaterialDto(20, "Lecture 20", new PrimitiveCollection<string>() {"Mobile", "C#"}, "", "Video", new DateTime(2021, 11, 12))
         };
 
         Assert.Equal(expected, result);
@@ -630,7 +630,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}),
+            new MaterialDto(16, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, "", "Video", new DateTime(2021, 10, 29)),
         };
 
         Assert.Equal(expected, result);
@@ -650,7 +650,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string>() {"C#"})
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string>() {"C#"}, "", "Book", new DateTime(2021, 2, 26))
         };
 
         Assert.Equal(expected, result);
@@ -670,7 +670,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string>() {"C#"})
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string>() {"C#"}, "", "Book", new DateTime(2021, 2, 26))
         };
 
         Assert.Equal(expected, result);
@@ -691,7 +691,7 @@ public class MaterialRepositoryTests
 
         IEnumerable<MaterialDto> expected = new PrimitiveCollection<MaterialDto>()
         {
-            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string>() {"C#"})
+            new MaterialDto(2, "C# 9.0 in a Nutshell", new PrimitiveCollection<string>() {"C#"}, "", "Book", new DateTime(2021, 2, 26))
         };
 
         Assert.Equal(expected, result);

--- a/Infrastructure.Tests/SearchTests.cs
+++ b/Infrastructure.Tests/SearchTests.cs
@@ -5,10 +5,10 @@ namespace blueberry.Infrastructure;
 public class SearchTests
 {
     private readonly IReadOnlyCollection<MaterialDto> _mockData = new[]{
-        new MaterialDto(1, "Why Haskell is better than F#", new PrimitiveCollection<string> {"FP", "Haskell", "F#", "The truth"}),
-        new MaterialDto(2, "Typescript and react", new PrimitiveCollection<string> {"React", "Typsescript", "Javascript"}),
-        new MaterialDto(3, "Why angular died", new PrimitiveCollection<string> {"Angular", "Typescript", "Javascript"}),
-        new MaterialDto(3, "Why typescript is the future of the web", new PrimitiveCollection<string> { "Typescript", "Javascript"}),
+        new MaterialDto(1, "Why Haskell is better than F#", new PrimitiveCollection<string> {"FP", "Haskell", "F#", "The truth"}, "", "Book", DateTime.Today),
+        new MaterialDto(2, "Typescript and react", new PrimitiveCollection<string> {"React", "Typsescript", "Javascript"}, "", "Book", DateTime.Today),
+        new MaterialDto(3, "Why angular died", new PrimitiveCollection<string> {"Angular", "Typescript", "Javascript"}, "", "Book", DateTime.Today),
+        new MaterialDto(3, "Why typescript is the future of the web", new PrimitiveCollection<string> { "Typescript", "Javascript"}, "", "Book", DateTime.Today),
     };
 
     [Fact]

--- a/Infrastructure/MaterialRepository.cs
+++ b/Infrastructure/MaterialRepository.cs
@@ -22,7 +22,6 @@ public class MaterialRepository : IMaterialRepository
         if (options.StartDate != null)
         {
             result = QueryStartDate(result, (DateTime)options.StartDate);
-            // FIXME: Here the count becomes 0 when supplied options from material controller
         }
 
         if (options.EndDate != null)
@@ -43,7 +42,7 @@ public class MaterialRepository : IMaterialRepository
         result = result.Take(options.Limit ?? 30);
 
         return await result
-            .Select(m => new MaterialDto(m.Id, m.Title, new PrimitiveCollection<string>(m.Tags.Select(t => t.Name))))
+            .Select(m => new MaterialDto(m.Id, m.Title, new PrimitiveCollection<string>(m.Tags.Select(t => t.Name)), m.ImageUrl, m.Type, m.Date))
             .ToListAsync();
     }
 

--- a/Server.Tests/MaterialControllerTests.cs
+++ b/Server.Tests/MaterialControllerTests.cs
@@ -20,8 +20,8 @@ public class MaterialControllerTests
         };
         var expected = new[]
         {
-            new MaterialDto(1, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(2, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(1, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, null, "Video", DateTime.Today),
+            new MaterialDto(2, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, null, "Video", DateTime.Today)
         };
         repository.Setup(m => m.Search(It.Is<SearchOptions>(o => o.Equals(mockOptions)))).ReturnsAsync(expected);
 
@@ -44,8 +44,8 @@ public class MaterialControllerTests
 
         var expected = new[]
          {
-            new MaterialDto(1, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}),
-            new MaterialDto(2, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"})
+            new MaterialDto(1, "Lecture 10", new PrimitiveCollection<string> {"Docker", "C#"}, null, "Video", DateTime.Today),
+            new MaterialDto(2, "Lecture 16", new PrimitiveCollection<string> {"Docker", "C#"}, null, "Video", DateTime.Today)
         };
         repository.Setup(m => m.Search(It.IsAny<SearchOptions>())).ReturnsAsync(expected.Skip(offset).Take(limit).ToList());
 


### PR DESCRIPTION
I have verified that the GET request to the Client returns JSON that now includes ImageURL, type, and date.